### PR TITLE
Fix invalid requests when having multiple records with the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Update the config parameters inside the update-cloudflare-dns_conf.ps1 by editin
 | telegram_chat_id       | ChangeMe    | Chat ID of the bot                |
 | telegram_bot_API_Token | ChangeMe    | Telegram's Bot API Token          |
 
+To find the telegram_chat_id try to use https://t.me/myidbot
+
 ### Optional Notification Parameters for Discord
 
 | **Option**             | **Example**                  | **Description**                               |

--- a/update-cloudflare-dns.ps1
+++ b/update-cloudflare-dns.ps1
@@ -104,6 +104,7 @@ Write-Output "==> DNS record of $dns_record is: $dns_record_ip. Trying to update
 $cloudflare_record_info = @{
   Uri     = "https://api.cloudflare.com/client/v4/zones/$zoneid/dns_records?name=$dns_record"
   Headers = @{"Authorization" = "Bearer $cloudflare_zone_api_token"; "Content-Type" = "application/json" }
+  Body = @{"type" = "A"}
 }
 
 $cloudflare_record_info_resposne = Invoke-RestMethod @cloudflare_record_info


### PR DESCRIPTION
Before the list method would list all the record_id with the same name and in the overwrite command it encountered an error. Now the first command list only the one with "A" type.